### PR TITLE
feat(skills): add skill repository, model and service

### DIFF
--- a/@types/index.ts
+++ b/@types/index.ts
@@ -28,6 +28,8 @@ export interface IDbFormat {
     __v: number  
 }
 
-export interface ICertificateFromDB extends ICertificate, IDbFormat {}
+export interface ICertificateFromDB extends ICertificate, IDbFormat {};
 
-export interface IProjectFormDB extends IProject, IDbFormat {}
+export interface IProjectFormDB extends IProject, IDbFormat {};
+
+export interface ISkillFormDB extends ISkill, IDbFormat {};

--- a/DB/models/projects.model.ts
+++ b/DB/models/projects.model.ts
@@ -1,9 +1,9 @@
 import { IProject } from "@/@types";
 import mongoose, { Schema } from "mongoose";
 
-export interface ICertificateDocument extends IProject, Document {}
+export interface IProjectDocument extends IProject, Document {}
 
-const projectSchema = new Schema<ICertificateDocument>({
+const projectSchema = new Schema<IProjectDocument>({
         title: {type: String, required: true},
         description:{type: String, required: true},
         imageUrl: {type: String, required: true},
@@ -14,6 +14,6 @@ const projectSchema = new Schema<ICertificateDocument>({
     { timestamps: true }
 )
 
-const ProjectModel = mongoose.models.ProjectModel || mongoose.model<ICertificateDocument>("Project", projectSchema);
+const ProjectModel = mongoose.models.ProjectModel || mongoose.model<IProjectDocument>("Project", projectSchema);
 
 export default ProjectModel;

--- a/DB/models/skill.model.ts
+++ b/DB/models/skill.model.ts
@@ -1,0 +1,16 @@
+import { ISkill } from "@/@types";
+import mongoose, { Schema } from "mongoose";
+
+export interface ISkillDocument extends ISkill, Document {}
+
+const skillSchema = new Schema<ISkillDocument>({
+        name: {type: String, required: true},
+        iconUrl:{type: String, required: true},
+        description: {type: String, required: true}
+    }, 
+    { timestamps: true }
+)
+
+const SkillModel = mongoose.models.SkillModel || mongoose.model<ISkillDocument>("Skill", skillSchema);
+
+export default SkillModel;

--- a/module/repositories/skill.repo.ts
+++ b/module/repositories/skill.repo.ts
@@ -1,0 +1,13 @@
+import { ISkill, ISkillFormDB } from "@/@types";
+import SkillModel from "@/DB/models/projects.model";
+
+class SkillRepo {
+    async getAllSkills() {
+        return await SkillModel.find({}).lean<ISkillFormDB[]>();
+    }
+    async addSkill(skillData: ISkill) {
+        return await SkillModel.insertOne(skillData);
+    }
+}
+
+export default new SkillRepo();

--- a/module/services/project.service.ts
+++ b/module/services/project.service.ts
@@ -2,7 +2,7 @@ import { IProject, IProjectFormDB } from "@/@types";
 import projectRepo from "../repositories/project.repo";
 
 class ProjectService {
-    async addCertificate(project: IProject): Promise<IProjectFormDB[] | null> {
+    async addProject(project: IProject): Promise<IProjectFormDB[] | null> {
         try {
             const newData = await projectRepo.addProject(project);
             return newData;
@@ -13,7 +13,7 @@ class ProjectService {
         }
     }
 
-    async getAllprojects(){
+    async getAllProjects(){
         try {
             const projects = await projectRepo.getAllProjects();
             return projects;

--- a/module/services/skill.service.ts
+++ b/module/services/skill.service.ts
@@ -1,0 +1,27 @@
+import { ISkill, ISkillFormDB } from "@/@types";
+import skillRepo from "../repositories/skill.repo";
+
+class SkillService {
+    async addSkill(skill: ISkill): Promise<ISkillFormDB[] | null> {
+        try {
+            const newData = await skillRepo.addSkill(skill);
+            return newData;
+        }
+        catch(error) {
+            console.error("Failed To add the new skill",error);
+            return null;
+        }
+    }
+
+    async getAllSkills(){
+        try {
+            const skills = await skillRepo.getAllSkills();
+            return skills;
+        }
+        catch(error) {
+            console.error("Failed to get skills!", error);
+            return null;
+        }
+    }
+}
+export default new SkillService();


### PR DESCRIPTION
Implement CRUD operations for skills including:
- Skill repository with getAllSkills and addSkill methods
- Skill model with mongoose schema
- Skill service with error handling
- Update type definitions for ISkillFormDB
- Fix project model interface naming inconsistency